### PR TITLE
Added the missing VNFs to the service descriptor.

### DIFF
--- a/network-service-descriptor/examples/sonata-demo.yml
+++ b/network-service-descriptor/examples/sonata-demo.yml
@@ -26,6 +26,14 @@ network_functions:
     vnf_group: "eu.sonata-nfv"
     vnf_name: "firewall-vnf"
     vnf_version: "0.1"
+  - vnf_id: "vnf_iperf"
+    vnf_group: "eu.sonata-nfv"
+    vnf_name: "iperf-vnf"
+    vnf_version: "0.1"
+  - vnf_id: "vnf_tcpdump"
+    vnf_group: "eu.sonata-nfv"
+    vnf_name: "tcpdump-vnf"
+    vnf_version: "0.1"
 
 ##
 ## The NS connection points to the 
@@ -47,14 +55,26 @@ virtual_links:
   - id: "mgmt"
     connectivity_type: "E-LAN"
     connection_points_reference:
+      - "vnf_iperf:mgmt"
       - "vnf_firewall:mgmt"
+      - "vnf_tcpdump:mgmt"
       - "ns:mgmt"
-  - id: "input"
+  - id: "input-2-iperf"
     connectivity_type: "E-Line"
     connection_points_reference:
-      - "vnf_firewall:input"
       - "ns:input"
-  - id: "output"
+      - "vnf_iperf:input"
+  - id: "iperf-2-firewall"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vnf_iperf:output"
+      - "vns_firewall:input"
+  - id: "firewall-2-tcpdump"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vns_firewall:output"
+      - "vnf_tcpdump:input"
+  - id: "tcpdump-2-output"
     connectivity_type: "E-Line"
     connection_points_reference:
       - "vnf_firewall:output"
@@ -66,19 +86,29 @@ virtual_links:
 forwarding_graphs:
   - fg_id: "ns:fg01"
     number_of_endpoints: 2
-    number_of_virtual_links: 2
+    number_of_virtual_links: 4
     constituent_vnfs:
+      - "vnf_iperf"
       - "vnf_firewall"
+      - "vnf_tcpdump"
     network_forwarding_paths:
       - fp_id: "ns:fg01:fp01"
         policy: "none"
         connection_points:
           - connection_point_ref: "ns:input"
             position: 1
-          - connection_point_ref: "vnf_firewall:input"
+          - connection_point_ref: "vnf_iperf:input"
             position: 2
-          - connection_point_ref: "vnf_firewall:output"
+          - connection_point_ref: "vnf_iperf:output"
             position: 3
-          - connection_point_ref: "ns:output"
+          - connection_point_ref: "vnf_firewall:input"
             position: 4
+          - connection_point_ref: "vnf_firewall:output"
+            position: 5
+          - connection_point_ref: "vnf_tcpdump:input"
+            position: 6
+          - connection_point_ref: "vnf_tcpdump:output"
+            position: 7
+          - connection_point_ref: "ns:output"
+            position: 8
 


### PR DESCRIPTION
The service descriptor now contains the three VNFs, namely the iperf-vnf, the firewall-vnf, and the tcpdump-vnf. It now reflects the SONATA demo setup as discussed in the Heidelberg meeting.
