### PR TITLE
descriptor for the vTC VNF

### DIFF
--- a/function-descriptor/examples/vtc-vnfd.yml
+++ b/function-descriptor/examples/vtc-vnfd.yml
@@ -1,0 +1,143 @@
+# YAML description of a firewall docker container
+# used in the SONATA platform
+
+---
+##
+## Some general information regarding this
+## VNF descriptor.
+##
+descriptor_version: "vnfd-schema-01"
+
+vendor: "eu.sonata-nfv"
+name: "firewall-vnf"
+version: "0.3"
+author: "Steven van Rossem, iMinds"
+description: >
+  "A first firewall VNF descriptor"
+
+##
+## Some function specific managers.
+##
+function_specific_managers:
+  - id: "fms01"
+    description: "A FSM based on Ubuntu 16.04 LTS."
+    image: "ubuntu:16.04"
+    options:
+      - key: "myKey"
+        value: "myValue"
+  - id: "fms02"
+    image: "ubuntu:14.04"
+    resource_requirements:
+      docker_version: "1.12"
+    options:
+      - key: "myKey"
+        value: "myValue"
+      - key: "myOhterKey"
+        value: "myOtherValue"
+
+##
+## The virtual deployment unit.
+##
+virtual_deployment_units:
+  - id: "vdu01"
+    vm_image: "http://registry.sonata-nfv.eu/html/files/VM_images/sonata-VM-2ports.qcow"
+    vm_image_format: "qcow2"
+    resource_requirements:
+      cpu:
+        vcpus: 1
+      memory:
+        size: 2
+        size_unit: "GB"
+      storage:
+        size: 10
+        size_unit: "GB"
+    monitoring_parameters:
+      - name: "vm_cpu_perc"
+        unit: "Percentage"
+      - name: "vm_mem_pers"
+        unit: "Percentage"
+      - name: "vm_net_rx_MB"
+        unit: "MB"
+      - name: "vm_net_tx_MB"
+        unit: "Mbps"
+    connection_points:
+      - id: "vdu01:eth0"
+        type: "interface"
+      - id: "vdu01:eth1"
+        type: "interface"
+      - id: "vdu01:eth2"
+        type: "interface"
+
+##
+## The virtual links that interconnect
+## the different connections points.
+##
+virtual_links:
+  - id: "mgmt"
+    connectivity_type: "E-LAN"
+    connection_points_reference:
+      - "vdu01:eth0"
+      - "mgmt"
+    dhcp: True
+  - id: "input"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:eth1"
+      - "input"
+    dhcp: True
+  - id: "output"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:eth2"
+      - "output"
+    dhcp: True
+
+##
+## The VNF connection points to the 
+## outside world.
+##
+connection_points:
+  - id: "mgmt"
+    type: "interface"
+  - id: "input"
+    type: "interface"
+  - id: "output"
+    type: "interface"
+
+##
+## The monitoring rules that react
+## to the monitoring parameters
+##
+monitoring_rules:
+  - name: "mon:rule:vm_cpu_perc"
+    description: "Trigger events if CPU load is above 10 percent."
+    duration: 10
+    duration_unit: "s"
+    condition: "vdu01:vm_cpu_perc > 10"
+    notification:
+      - name: "notification01"
+        type: "rabbitmq_message"
+  - name: "mon:rule:vm_mem_perc"
+    description: "Trigger events if memory consumption is above 10 percent."
+    duration: 10
+    duration_unit: "s"
+    condition: "vdu01:vm_mem_perc > 10"
+    notification:
+      - name: "notification02"
+        type: "rabbitmq_message"
+  - name: "mon:rule:rx"
+    duration: 10
+    duration_unit: "s"
+    condition: "vdu01:vm_net_rx_MB > 10"
+    notification:
+      - name: "notification03"
+        type: "rabbitmq_message"
+  - name: "mon:rule:tx"
+    duration: 10
+    duration_unit: "s"
+    condition: "vdu01:vm_net_tx_MB > 10"
+    notification:
+      - name: "notification04"
+        type: "rabbitmq_message"
+
+

--- a/function-descriptor/examples/vtc-vnfd.yml
+++ b/function-descriptor/examples/vtc-vnfd.yml
@@ -98,10 +98,10 @@ virtual_deployment_units:
         type: "interface" #this is the only interface that should get floating IP address. traffic for the other interfaces will be forwarded via the SDN controller" 
         access: "public" #signal the allocation of public IP from the allocated segment for this tenant. 
       #Data-in interface
-      - id: "vdu01:eth1"
+      - id: "vdu02:eth1"
         type: "interface"
       #Data-out interfaces
-      - id: "vdu01:eth2"
+      - id: "vdu02:eth2"
         type: "interface"
 ##
 ## The virtual links that interconnect
@@ -112,18 +112,18 @@ virtual_links:
     connectivity_type: "E-LAN"
     connection_points_reference:
       - "vdu01:eth0"
-      - "mgmt"
+      - "vdu02:eth0"
     dhcp: True
   - id: "input"
     connectivity_type: "E-Line"
     connection_points_reference:
-      - "vdu01:eth1"
+      - "vdu02:eth1"
       - "input"
     dhcp: True
   - id: "output"
     connectivity_type: "E-Line"
     connection_points_reference:
-      - "vdu01:eth2"
+      - "vdu02:eth2"
       - "output"
     dhcp: True
 

--- a/function-descriptor/examples/vtc-vnfd.yml
+++ b/function-descriptor/examples/vtc-vnfd.yml
@@ -9,23 +9,26 @@
 descriptor_version: "vnfd-schema-01"
 
 vendor: "eu.sonata-nfv"
-name: "firewall-vnf"
-version: "0.3"
-author: "Steven van Rossem, iMinds"
+name: "vtc-vnf"
+version: "0.1"
+author: "George Xilouris, NCSRD"
 description: >
-  "A first firewall VNF descriptor"
+  "Virtual traffic classifier (vTC) descriptor file. vTC uses ndpi library for the implementation of the vTC"
 
 ##
 ## Some function specific managers.
 ##
+
+## NOTE : this sub-section of the VNFD is not complete 
 function_specific_managers:
-  - id: "fms01"
-    description: "A FSM based on Ubuntu 16.04 LTS."
-    image: "ubuntu:16.04"
+  - id: "fsm00"
+    description: "FSM for controlling the classification capabilities of the vTC"
+    image: "ubuntu:14.04"
     options:
       - key: "myKey"
         value: "myValue"
-  - id: "fms02"
+  - id: "fsm01"
+    description: "FSM for management of the start/stop lifecycle of the vTC"
     image: "ubuntu:14.04"
     resource_requirements:
       docker_version: "1.12"
@@ -40,7 +43,8 @@ function_specific_managers:
 ##
 virtual_deployment_units:
   - id: "vdu01"
-    vm_image: "http://registry.sonata-nfv.eu/html/files/VM_images/sonata-VM-2ports.qcow"
+    description: "VNFC for the dashboard and the time-series database"
+    vm_image: "TBD"
     vm_image_format: "qcow2"
     resource_requirements:
       cpu:
@@ -49,7 +53,7 @@ virtual_deployment_units:
         size: 2
         size_unit: "GB"
       storage:
-        size: 10
+        size: 20
         size_unit: "GB"
     monitoring_parameters:
       - name: "vm_cpu_perc"
@@ -61,13 +65,44 @@ virtual_deployment_units:
       - name: "vm_net_tx_MB"
         unit: "Mbps"
     connection_points:
+      #Management interface
       - id: "vdu01:eth0"
         type: "interface"
+
+
+  - id: "vdu02"
+    vm_image: "TBD"
+    description: "VNFC for the DPI functionality"
+    vm_image_format: "qcow2"
+    resource_requirements:
+      cpu:
+        vcpus: 1
+      memory:
+        size: 2
+        size_unit: "GB"
+      storage:
+        size: 5
+        size_unit: "GB"
+    monitoring_parameters:
+      - name: "vm_cpu_perc"
+        unit: "Percentage"
+      - name: "vm_mem_pers"
+        unit: "Percentage"
+      - name: "vm_net_rx_MB"
+        unit: "MB"
+      - name: "vm_net_tx_MB"
+        unit: "Mbps"
+    connection_points:
+      #Management interface
+      - id: "vdu02:eth0"
+        type: "interface" #this is the only interface that should get floating IP address. traffic for the other interfaces will be forwarded via the SDN controller" 
+        access: "public" #signal the allocation of public IP from the allocated segment for this tenant. 
+      #Data-in interface
       - id: "vdu01:eth1"
         type: "interface"
+      #Data-out interfaces
       - id: "vdu01:eth2"
         type: "interface"
-
 ##
 ## The virtual links that interconnect
 ## the different connections points.
@@ -91,18 +126,6 @@ virtual_links:
       - "vdu01:eth2"
       - "output"
     dhcp: True
-
-##
-## The VNF connection points to the 
-## outside world.
-##
-connection_points:
-  - id: "mgmt"
-    type: "interface"
-  - id: "input"
-    type: "interface"
-  - id: "output"
-    type: "interface"
 
 ##
 ## The monitoring rules that react


### PR DESCRIPTION
Looks OK to me. See the comments on the commit. 

added 
#Management interface
      - id: "vdu02:eth0"
        type: "interface" #this is the only interface that should get floating IP address. traffic for the other interfaces will be forwarded via the SDN controller" 
        access: "public" #signal the allocation of public IP from the allocated segment for this tenant. 

access denotes the assignment of floating IP on the interface. 