### PR TITLE
Interface definition for vnfr and nsr

### DIFF
--- a/function-record/vnfr-schema.yml
+++ b/function-record/vnfr-schema.yml
@@ -205,9 +205,7 @@ properties:
                     interface:
                       description: "The type of connection point, such as a virtual port, a virtual NIC address, a physical port, a physcial NIC address, or the endpoint of a VPN tunnel."
                       oneOf:
-                        - $ref: "#/definitions/interfaces/ethernet"
-                        - $ref: "#/definitions/interfaces/ipv4"
-                        - $ref: "#/definitions/interfaces/ipv6"
+                        - $ref: "#/definitions/interfaces"
                     type:
                       description: "The type of the connection point with respect to its visibility in the service platform"
                       $ref: "#/definitions/connection_point_types"

--- a/service-record/nsr-schema.yml
+++ b/service-record/nsr-schema.yml
@@ -117,9 +117,7 @@ properties:
         interface:
           description: "The type of connection point, such as a virtual port, a virtual NIC address, a physical port, a physcial NIC address, or the endpoint of a VPN tunnel."
           oneOf:
-            - $ref: "#/definitions/interfaces/ethernet"
-            - $ref: "#/definitions/interfaces/ipv4"
-            - $ref: "#/definitions/interfaces/ipv6"
+            - $ref: "#/definitions/interfaces"
         type:
           description: "The type of the connection point with respect to its visibility in the service platform"
           $ref: "#/definitions/connection_point_types"


### PR DESCRIPTION
This fix the following error:

message': "The property '#/virtual_deployment_units/0/vnfc_instance/0/connection_points/0/interface' of type Hash matched more than one of the required schemas in schema 8453f98c-55af-5e4c-99b9-0c1e4d729fa6\n