### PR TITLE
New license sections

### DIFF
--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -125,6 +125,37 @@ properties:
   description:
     description: "A longer description of the network function."
     type: "string"
+  licenses:
+    description: "Information on the license of this VNFD."
+    type: "array"
+    items:
+      anyOf:
+        - type: "object"
+          properties:
+            type:
+              description: "The type of license, 'public' in this case."
+              type: "string"
+              enum:
+              - "public"
+          required:
+            - "type"
+          additionalProperties: false
+        - type: "object"
+          properties:
+            type:
+              description: "The type of license, 'private' in this case."
+              type: "string"
+              enum:
+              - "private"
+            url:
+              description: "The URL to the license file."
+              type: "string"
+          required:
+            - "type"
+            - "url"
+          additionalProperties: false
+    additionalItems: false
+    uniqueItems: true
   function_specific_managers:
     description: "A list of FSMs used to manage this VNF."
     type: "array"

--- a/service-descriptor/nsd-schema.yml
+++ b/service-descriptor/nsd-schema.yml
@@ -45,6 +45,37 @@ properties:
   description:
     description: "A longer description of the network service."
     type: "string"
+  licenses:
+    description: "Information on the license of this NSD."
+    type: "array"
+    items:
+      anyOf:
+        - type: "object"
+          properties:
+            type:
+              description: "The type of license, 'public' in this case."
+              type: "string"
+              enum:
+              - "public"
+          required:
+            - "type"
+          additionalProperties: false
+        - type: "object"
+          properties:
+            type:
+              description: "The type of license, 'private' in this case."
+              type: "string"
+              enum:
+              - "private"
+            url:
+              description: "The URL to the license file."
+              type: "string"
+          required:
+            - "type"
+            - "url"
+          additionalProperties: false
+    additionalItems: false
+    uniqueItems: true
   service_specific_managers:
     description: "A list of SSMs used to manage this network service."
     type: "array"


### PR DESCRIPTION
Both, VNFD and NSD now have license sections to specify (multiple) licenses.
Licenses have to be an array with unique items.
Exampe:

...
licenses:
  - type: public
  - type: private
    url: http://url1
  - type: private
    url: http://url2